### PR TITLE
Remove bottom scroll bar from About page

### DIFF
--- a/about.html
+++ b/about.html
@@ -77,7 +77,7 @@
 				<h2>Meet Our Officers</h2>
 			</div>
 			<div id="exec">
-				<div class="row mb-4 justify-content-center" style="color: black">
+				<div class="row no-gutters mb-4 justify-content-center" style="color: black">
 					<div class="card col-md-3 p-0 m-4" id="President-card">
 						<img id="President-img" src="assets/img/officers/profile.png" class="card-img-top" alt="President"/>
 						<div class="card-body">


### PR DESCRIPTION
Remove margin from exec cards to eliminate the scroll bar on the bottom of the about page.